### PR TITLE
Fix: Enable Cascade delte

### DIFF
--- a/composeApp/src/commonMain/kotlin/com/biondic/rssreader/core/database/ProvideDatabase.kt
+++ b/composeApp/src/commonMain/kotlin/com/biondic/rssreader/core/database/ProvideDatabase.kt
@@ -3,4 +3,7 @@ package com.biondic.rssreader.core.database
 import app.cash.sqldelight.db.SqlDriver
 import com.biondic.rssreader.RssDatabase
 
-fun provideDatabase(driver: SqlDriver): RssDatabase = RssDatabase(driver)
+fun provideDatabase(driver: SqlDriver): RssDatabase {
+    driver.execute(null, "PRAGMA foreign_keys = ON", 0)
+    return RssDatabase(driver)
+}


### PR DESCRIPTION
**This PR includes:**

- Enabled cascade delete of entities related to subscription..

**What was the issue:** 
Even tho we defined `ON DELETE CASCADE` in the `Article.sq `, cascade delete was not executed because foreign keys are not allowed in the database setup